### PR TITLE
Remove SonarCloud cache setup as it is now offered by default

### DIFF
--- a/.github/workflows/ci-sonar-scan.yml
+++ b/.github/workflows/ci-sonar-scan.yml
@@ -121,12 +121,6 @@ jobs:
           path: Build/Output/ExternalsCache
           key: ExternalsCache-${{ matrix.config_preset }}-${{ hashFiles('Externals/*.cmake') }}
 
-      - name: Initialize Sonar Cache
-        uses: actions/cache@v3
-        with:
-          path: .sonar/cache
-          key: SonarCache-v2-${{ runner.os }}
-
       - name: Setup Developer Command Prompt for MSVC (VS2022 x64) to build with Ninja
         if: ${{ matrix.os_name == 'windows' }}
         uses: ilammy/msvc-dev-cmd@v1

--- a/Build/Unix/Build.sh
+++ b/Build/Unix/Build.sh
@@ -251,10 +251,7 @@ if [ "$IS_ANALYZE_BUILD" == true ]; then
         -Dsonar.sources="Apps,Modules" \
         -Dsonar.host.url="https://sonarcloud.io" \
         -Dsonar.login="$SONAR_TOKEN" \
-        -Dsonar.cfamily.build-wrapper-output="$BUILD_DIR" \
-        -Dsonar.cfamily.cache.path="$SONAR_SCANNER_DIR/Cache" \
-        -Dsonar.cfamily.threads=16 \
-        -Dsonar.cfamily.cache.enabled=true; then
+        -Dsonar.cfamily.build-wrapper-output="$BUILD_DIR"; then
         echo "Sonar-scanner build failed."
         exit 1
     fi

--- a/Build/Windows/Build.bat
+++ b/Build/Windows/Build.bat
@@ -180,10 +180,7 @@ IF DEFINED ANALYZE_BUILD (
         -D sonar.sources="Apps,Modules"^
         -D sonar.host.url="https://sonarcloud.io"^
         -D sonar.login="%SONAR_TOKEN%"^
-        -D sonar.cfamily.build-wrapper-output="%BUILD_DIR%"^
-        -D sonar.cfamily.cache.path="%SONAR_SCANNER_DIR%\Cache"^
-        -D sonar.cfamily.threads=16^
-        -D sonar.cfamily.cache.enabled=true
+        -D sonar.cfamily.build-wrapper-output="%BUILD_DIR%"
     IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ) ELSE (

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,3 @@ sonar.sources=Apps,Modules
 sonar.tests=Tests
 sonar.sourceEncoding=UTF-8
 sonar.verbose=false
-
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=.sonar/cache


### PR DESCRIPTION
No need to configure the cache anymore, SonarCloud now has an automatic analysis caching. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.