### PR TITLE
Fix wrong comment encoding

### DIFF
--- a/Modules/UserInterface/Widgets/Sources/Methane/UserInterface/HeadsUpDisplay.cpp
+++ b/Modules/UserInterface/Widgets/Sources/Methane/UserInterface/HeadsUpDisplay.cpp
@@ -18,16 +18,15 @@ limitations under the License.
 
 FILE: Methane/UserInterface/HeadsUpDisplay.cpp
 Heads-Up-Display widget for displaying runtime rendering parameters.
-
- ╔═══════════════╤════════════════════════════════╗
- ║ F1 - Help     │ GPU Adapter Name               ║
- ╟───────────────┼────────────────────────────────╢
- ║ Frame Time ms │                                ║
- ╟───────────────┥ 123 FPS (Major Font)           ║
- ║ CPU Time %    │                                ║
- ╟───────────────┼────────────────────────────────╢
- ║ VSync ON/OFF  │ W x H       N FB      GFX API  ║
- ╚═══════════════╧════════════════════════════════╝
+ --------------------------------------------------
+ | F1 - Help     | GPU Adapter Name               |
+ |-------------- |--------------------------------|
+ | Frame Time ms |                                |
+ |-------------- | 123 FPS (Major Font)           |
+ | CPU Time %    |                                |
+ |-------------- |--------------------------------|
+ | VSync ON/OFF  | W x H       N FB      GFX API  |
+ --------------------------------------------------
 
 ******************************************************************************/
 


### PR DESCRIPTION
When compiling with Visual Studio, the error message ``This file contains characters that cannot be represented in the current code page (936). Please save the file as Unicode format to prevent data loss.`` indicates that special encoding format is used in the comments.